### PR TITLE
Correcciones plantilla

### DIFF
--- a/Modulaciones_digitales/lab18/lab18.tex
+++ b/Modulaciones_digitales/lab18/lab18.tex
@@ -5,7 +5,7 @@
 \pgfdeclareimage[width=\paperwidth,height=\paperheight]{bg}{imagenes/fondo_lab}
 \setbeamertemplate{background}{\pgfuseimage{bg}}
 
-\bfseries{\textrm{ \Large Lab 18: \\Esquema de la Modulación y \\Demodulación DPSK \\en GNU Radio}}
+\bfseries{\textrm{\Large Lab 18:\\ \large Esquema de la Modulación y \\Demodulación DPSK \\en GNU Radio}}
 \raggedright
 \end{frame}
 %********************

--- a/Modulaciones_digitales/lab19/lab19.tex
+++ b/Modulaciones_digitales/lab19/lab19.tex
@@ -6,7 +6,7 @@
 \pgfdeclareimage[width=\paperwidth,height=\paperheight]{bg}{imagenes/fondo_lab}
 \setbeamertemplate{background}{\pgfuseimage{bg}}
 
-\bfseries{\textrm{ \Large Lab 19: \\Modulación QPSK - Transmisión y Recepción}}
+\bfseries{\textrm{\large Lab 19: \\ Modulación QPSK \\Transmisión y Recepción}}
 \raggedright
 \end{frame}
 %********************

--- a/Modulaciones_digitales/lab20/lab20.tex
+++ b/Modulaciones_digitales/lab20/lab20.tex
@@ -1,4 +1,4 @@
-\subsection{Lab20:Modulacion digital QAM}
+\subsection{Lab20: Modulacion digital QAM}
 
 %*********************
 \begin{frame}{}
@@ -11,6 +11,8 @@
 \end{frame}
 %*********************
 
+\pgfdeclareimage[width=\paperwidth,height=\paperheight]{bg}{imagenes/fondo3}
+\setbeamertemplate{background}{\pgfuseimage{bg}}
 \begin{frame}{Modulacion de amplitud en cuadratura QAM}
 \begin{flushleft}
 La modulación de amplitud en cuadratura, en inglés Quadrature Amplitude Modulation (QAM), es una técnica de modulación digital avanzada que transporta datos, técnica en la cual la informacion va a ser modulada tanto en amplitud como en fase (la señal de portadora va a ser modificada en amplitud y fase) o sea que la informacion digital está contenida, tanto en la amplitud como en la fase de la portadora trasmitida. Esto se consigue modulando una misma portadora, desfasando 90º la fase y la amplitud.

--- a/Modulaciones_digitales/lab21/lab21.tex
+++ b/Modulaciones_digitales/lab21/lab21.tex
@@ -1,4 +1,5 @@
-\subsection{Lab21:Filter taps}
+\pgfdeclareimage[width=\paperwidth,height=\paperheight]{bg}{imagenes/fondo_lab}
+\setbeamertemplate{background}{\pgfuseimage{bg}}\subsection{Lab21: Filter taps}
 
 %*********************
 \begin{frame}{}
@@ -11,6 +12,9 @@
 \end{frame}
 %*********************
 
+
+\pgfdeclareimage[width=\paperwidth,height=\paperheight]{bg}{imagenes/fondo3}
+\setbeamertemplate{background}{\pgfuseimage{bg}}
 \begin{frame}{Filter taps}
 Taps
 \begin{flushleft}
@@ -89,10 +93,10 @@ Una función de impulso permite evidenciar que la señal es cero (0) siempre, ex
 \begin{frame}{Filter taps}
 PASOS PARA OBTENER LA FRECUENCIA DE CORTE EN CADA FILTRO
 \begin{flushleft}
-1.	Lo primero que se debe tener en cuenta es el nivel máximo  (en dB’s) de la señal.
-2.	Según la teoría la señal se encuentra a la mitad de su potencia cuando gráficamente este disminuye 3 dB’s.
-3.	Se debe activar el rango de Average en el WX GUI FFT sink  con el valor mínimo.
-4.	Seguido de eso podremos observar la frecuencia en la que se encuentra la señal en el momento de medir estos -3 dB’s.
+1.	Lo primero que se debe tener en cuenta es el nivel máximo  (en dB’s) de la señal.\\
+2.	Según la teoría la señal se encuentra a la mitad de su potencia cuando gráficamente este disminuye 3 dB’s.\\
+3.	Se debe activar el rango de Average en el WX GUI FFT sink  con el valor mínimo.\\
+4.	Seguido de eso podremos observar la frecuencia en la que se encuentra la señal en el momento de medir estos -3 dB’s.\\
 5.	Tomar esa frecuencia como la frecuencia de corte inicial, final, o ambas según el filtro que se este utilizando. 
 \end{flushleft}
 \end{frame}

--- a/Modulaciones_digitales/lab22/lab22.tex
+++ b/Modulaciones_digitales/lab22/lab22.tex
@@ -6,7 +6,7 @@
 \pgfdeclareimage[width=\paperwidth,height=\paperheight]{bg}{imagenes/fondo_lab}
 \setbeamertemplate{background}{\pgfuseimage{bg}}
 
-\bfseries{\textrm{\LARGE Actividad\\ \Large Embedded Python Block}}
+\bfseries{\textrm{\LARGE Lab22\\ \Large Embedded Python Block}}
 \raggedright
 \end{frame}
 %*********************
@@ -45,38 +45,36 @@
 \setbeamertemplate{background}{\pgfuseimage{bg}}
 
   \begin{itemize}
-  \item \justifying Después de haber elegido nuestro editor por defecto o editor de texto preferente se nos genera un codigo del bloque. en el cual se ingresaran los parametros como se observara a continuacion en el ejemplo
+  \item \justifying Después de haber elegido nuestro editor por defecto o editor de texto preferente se nos genera un codigo del bloque. en el cual se ingresaran los parametros como se observara a continuacion en el ejemplo.
 
-
- 
   \end{itemize}
 \end{frame}
 %---------------------------
 
 \begin{frame}{Python block}
+\vspace{-3mm}
+\begin{figure}[H]
+\centering
+\includegraphics[width=\textwidth]{Modulaciones_digitales/lab22/pdf/lab22_1.pdf}
+\end{figure}
+\end{frame}
+%_---------------------
+
+\begin{frame}{Python block}
 \vspace{-1cm}
 \begin{figure}[H]
 \centering
-\includegraphics[width=1.1\textwidth]{Modulaciones_digitales/lab22/pdf/lab22_1.pdf}
-\end{figure}
-\end{frame}
-%_---------------------
-
-\begin{frame}{Python block}
-\vspace{-1.5cm}
-\begin{figure}[H]
-\centering
-\includegraphics[width=1.1\textwidth]{Modulaciones_digitales/lab22/pdf/lab22_2.pdf}
+\includegraphics[width=\textwidth]{Modulaciones_digitales/lab22/pdf/lab22_2.pdf}
 \end{figure}
 \end{frame}
 %_---------------------
 %_---------------------
 
 \begin{frame}{Python block}
-\vspace{-1.5cm}
+\vspace{-1cm}
 \begin{figure}[H]
 \centering
-\includegraphics[width=1.1\textwidth]{Modulaciones_digitales/lab22/pdf/lab22_3.pdf}
+\includegraphics[width=\textwidth]{Modulaciones_digitales/lab22/pdf/lab22_3.pdf}
 \end{figure}
 \end{frame}
 %_---------------------

--- a/Modulaciones_digitales/lab24/lab24.tex
+++ b/Modulaciones_digitales/lab24/lab24.tex
@@ -6,7 +6,7 @@
 \pgfdeclareimage[width=\paperwidth,height=\paperheight]{bg}{imagenes/fondo_lab}
 \setbeamertemplate{background}{\pgfuseimage{bg}}
 
-\bfseries{\textrm{\LARGE Lab24\\ \Large Constelación y FFT, Modulación BPSK}}
+\bfseries{\textrm{\LARGE Lab24\\ \Large Constelación y FFT \\Modulación BPSK}}
 \raggedright
 \end{frame}
 %*********************

--- a/Modulaciones_digitales/lab25/lab8.tex
+++ b/Modulaciones_digitales/lab25/lab8.tex
@@ -1,21 +1,20 @@
-\subsection{GENERADOR ALEATORIO DE PDU}
+\subsection{Lab25: Generador Aleatorio de PDU}
 %*********************
 \begin{frame}{}
 
 \pgfdeclareimage[width=\paperwidth,height=\paperheight]{bg}{imagenes/fondo_lab}
 \setbeamertemplate{background}{\pgfuseimage{bg}}
 
-\bfseries{\textrm{\LARGE Lab17\\ \Large GENERADOR ALEATORIO DE PDU}}
+\bfseries{\textrm{\LARGE Lab25\\ \Large Generador Aleatorio \\de PDU}}
 \raggedright
 \end{frame}
 %*********************
 
 
-
-
 %\end{frame}
 %---------------------------------
-
+\pgfdeclareimage[width=\paperwidth,height=\paperheight]{bg}{imagenes/fondo3}
+\setbeamertemplate{background}{\pgfuseimage{bg}}
 \begin{frame}{PASO 1: UNIDADES DE DATOS DE PROTOCOLOS (PDU)}
 
 \begin{figure}[H]

--- a/SDR-digital.nav
+++ b/SDR-digital.nav
@@ -66,45 +66,45 @@
 \headcommand {\beamer@framepages {30}{30}}
 \headcommand {\slideentry {1}{3}{8}{31/31}{Lab19: Modulaci\IeC {\'o}n QPSK - Transmision y recepcion}{0}}
 \headcommand {\beamer@framepages {31}{31}}
-\headcommand {\beamer@subsectionentry {0}{1}{4}{32}{Lab20:Modulacion digital QAM}}\headcommand {\beamer@subsectionpages {24}{31}}
-\headcommand {\slideentry {1}{4}{1}{32/32}{Lab20:Modulacion digital QAM}{0}}
+\headcommand {\beamer@subsectionentry {0}{1}{4}{32}{Lab20: Modulacion digital QAM}}\headcommand {\beamer@subsectionpages {24}{31}}
+\headcommand {\slideentry {1}{4}{1}{32/32}{Lab20: Modulacion digital QAM}{0}}
 \headcommand {\beamer@framepages {32}{32}}
-\headcommand {\slideentry {1}{4}{2}{33/33}{Lab20:Modulacion digital QAM}{0}}
+\headcommand {\slideentry {1}{4}{2}{33/33}{Lab20: Modulacion digital QAM}{0}}
 \headcommand {\beamer@framepages {33}{33}}
-\headcommand {\slideentry {1}{4}{3}{34/34}{Lab20:Modulacion digital QAM}{0}}
+\headcommand {\slideentry {1}{4}{3}{34/34}{Lab20: Modulacion digital QAM}{0}}
 \headcommand {\beamer@framepages {34}{34}}
-\headcommand {\slideentry {1}{4}{4}{35/35}{Lab20:Modulacion digital QAM}{0}}
+\headcommand {\slideentry {1}{4}{4}{35/35}{Lab20: Modulacion digital QAM}{0}}
 \headcommand {\beamer@framepages {35}{35}}
-\headcommand {\slideentry {1}{4}{5}{36/36}{Lab20:Modulacion digital QAM}{0}}
+\headcommand {\slideentry {1}{4}{5}{36/36}{Lab20: Modulacion digital QAM}{0}}
 \headcommand {\beamer@framepages {36}{36}}
-\headcommand {\slideentry {1}{4}{6}{37/37}{Lab20:Modulacion digital QAM}{0}}
+\headcommand {\slideentry {1}{4}{6}{37/37}{Lab20: Modulacion digital QAM}{0}}
 \headcommand {\beamer@framepages {37}{37}}
-\headcommand {\slideentry {1}{4}{7}{38/38}{Lab20:Modulacion digital QAM}{0}}
+\headcommand {\slideentry {1}{4}{7}{38/38}{Lab20: Modulacion digital QAM}{0}}
 \headcommand {\beamer@framepages {38}{38}}
-\headcommand {\slideentry {1}{4}{8}{39/39}{Lab20:Modulacion digital QAM}{0}}
+\headcommand {\slideentry {1}{4}{8}{39/39}{Lab20: Modulacion digital QAM}{0}}
 \headcommand {\beamer@framepages {39}{39}}
-\headcommand {\slideentry {1}{4}{9}{40/40}{Lab20:Modulacion digital QAM}{0}}
+\headcommand {\slideentry {1}{4}{9}{40/40}{Lab20: Modulacion digital QAM}{0}}
 \headcommand {\beamer@framepages {40}{40}}
-\headcommand {\beamer@subsectionentry {0}{1}{5}{41}{Lab21:Filter taps}}\headcommand {\beamer@subsectionpages {32}{40}}
-\headcommand {\slideentry {1}{5}{1}{41/41}{Lab21:Filter taps}{0}}
+\headcommand {\beamer@subsectionentry {0}{1}{5}{41}{Lab21: Filter taps}}\headcommand {\beamer@subsectionpages {32}{40}}
+\headcommand {\slideentry {1}{5}{1}{41/41}{Lab21: Filter taps}{0}}
 \headcommand {\beamer@framepages {41}{41}}
-\headcommand {\slideentry {1}{5}{2}{42/42}{Lab21:Filter taps}{0}}
+\headcommand {\slideentry {1}{5}{2}{42/42}{Lab21: Filter taps}{0}}
 \headcommand {\beamer@framepages {42}{42}}
-\headcommand {\slideentry {1}{5}{3}{43/43}{Lab21:Filter taps}{0}}
+\headcommand {\slideentry {1}{5}{3}{43/43}{Lab21: Filter taps}{0}}
 \headcommand {\beamer@framepages {43}{43}}
-\headcommand {\slideentry {1}{5}{4}{44/44}{Lab21:Filter taps}{0}}
+\headcommand {\slideentry {1}{5}{4}{44/44}{Lab21: Filter taps}{0}}
 \headcommand {\beamer@framepages {44}{44}}
-\headcommand {\slideentry {1}{5}{5}{45/45}{Lab21:Filter taps}{0}}
+\headcommand {\slideentry {1}{5}{5}{45/45}{Lab21: Filter taps}{0}}
 \headcommand {\beamer@framepages {45}{45}}
-\headcommand {\slideentry {1}{5}{6}{46/46}{Lab21:Filter taps}{0}}
+\headcommand {\slideentry {1}{5}{6}{46/46}{Lab21: Filter taps}{0}}
 \headcommand {\beamer@framepages {46}{46}}
-\headcommand {\slideentry {1}{5}{7}{47/47}{Lab21:Filter taps}{0}}
+\headcommand {\slideentry {1}{5}{7}{47/47}{Lab21: Filter taps}{0}}
 \headcommand {\beamer@framepages {47}{47}}
-\headcommand {\slideentry {1}{5}{8}{48/48}{Lab21:Filter taps}{0}}
+\headcommand {\slideentry {1}{5}{8}{48/48}{Lab21: Filter taps}{0}}
 \headcommand {\beamer@framepages {48}{48}}
-\headcommand {\slideentry {1}{5}{9}{49/49}{Lab21:Filter taps}{0}}
+\headcommand {\slideentry {1}{5}{9}{49/49}{Lab21: Filter taps}{0}}
 \headcommand {\beamer@framepages {49}{49}}
-\headcommand {\slideentry {1}{5}{10}{50/50}{Lab21:Filter taps}{0}}
+\headcommand {\slideentry {1}{5}{10}{50/50}{Lab21: Filter taps}{0}}
 \headcommand {\beamer@framepages {50}{50}}
 \headcommand {\beamer@subsectionentry {0}{1}{6}{51}{Lab22: Python block}}\headcommand {\beamer@subsectionpages {41}{50}}
 \headcommand {\slideentry {1}{6}{1}{51/51}{Lab22: Python block}{0}}
@@ -177,44 +177,44 @@
 \headcommand {\beamer@framepages {83}{83}}
 \headcommand {\slideentry {1}{8}{11}{84/84}{Lab24: Constelaci\IeC {\'o}n y FFT, Modulaci\IeC {\'o}n BPSK}{0}}
 \headcommand {\beamer@framepages {84}{84}}
-\headcommand {\beamer@subsectionentry {0}{1}{9}{85}{GENERADOR ALEATORIO DE PDU}}\headcommand {\beamer@subsectionpages {74}{84}}
-\headcommand {\slideentry {1}{9}{1}{85/85}{GENERADOR ALEATORIO DE PDU}{0}}
+\headcommand {\beamer@subsectionentry {0}{1}{9}{85}{Lab25: Generador Aleatorio de PDU}}\headcommand {\beamer@subsectionpages {74}{84}}
+\headcommand {\slideentry {1}{9}{1}{85/85}{Lab25: Generador Aleatorio de PDU}{0}}
 \headcommand {\beamer@framepages {85}{85}}
-\headcommand {\slideentry {1}{9}{2}{86/86}{GENERADOR ALEATORIO DE PDU}{0}}
+\headcommand {\slideentry {1}{9}{2}{86/86}{Lab25: Generador Aleatorio de PDU}{0}}
 \headcommand {\beamer@framepages {86}{86}}
-\headcommand {\slideentry {1}{9}{3}{87/87}{GENERADOR ALEATORIO DE PDU}{0}}
+\headcommand {\slideentry {1}{9}{3}{87/87}{Lab25: Generador Aleatorio de PDU}{0}}
 \headcommand {\beamer@framepages {87}{87}}
-\headcommand {\slideentry {1}{9}{4}{88/88}{GENERADOR ALEATORIO DE PDU}{0}}
+\headcommand {\slideentry {1}{9}{4}{88/88}{Lab25: Generador Aleatorio de PDU}{0}}
 \headcommand {\beamer@framepages {88}{88}}
-\headcommand {\slideentry {1}{9}{5}{89/89}{GENERADOR ALEATORIO DE PDU}{0}}
+\headcommand {\slideentry {1}{9}{5}{89/89}{Lab25: Generador Aleatorio de PDU}{0}}
 \headcommand {\beamer@framepages {89}{89}}
-\headcommand {\slideentry {1}{9}{6}{90/90}{GENERADOR ALEATORIO DE PDU}{0}}
+\headcommand {\slideentry {1}{9}{6}{90/90}{Lab25: Generador Aleatorio de PDU}{0}}
 \headcommand {\beamer@framepages {90}{90}}
-\headcommand {\slideentry {1}{9}{7}{91/91}{GENERADOR ALEATORIO DE PDU}{0}}
+\headcommand {\slideentry {1}{9}{7}{91/91}{Lab25: Generador Aleatorio de PDU}{0}}
 \headcommand {\beamer@framepages {91}{91}}
-\headcommand {\slideentry {1}{9}{8}{93/93}{GENERADOR ALEATORIO DE PDU}{0}}
+\headcommand {\slideentry {1}{9}{8}{93/93}{Lab25: Generador Aleatorio de PDU}{0}}
 \headcommand {\beamer@framepages {93}{93}}
-\headcommand {\slideentry {1}{9}{9}{94/94}{GENERADOR ALEATORIO DE PDU}{0}}
+\headcommand {\slideentry {1}{9}{9}{94/94}{Lab25: Generador Aleatorio de PDU}{0}}
 \headcommand {\beamer@framepages {94}{94}}
-\headcommand {\slideentry {1}{9}{10}{95/95}{GENERADOR ALEATORIO DE PDU}{0}}
+\headcommand {\slideentry {1}{9}{10}{95/95}{Lab25: Generador Aleatorio de PDU}{0}}
 \headcommand {\beamer@framepages {95}{95}}
-\headcommand {\slideentry {1}{9}{11}{96/96}{GENERADOR ALEATORIO DE PDU}{0}}
+\headcommand {\slideentry {1}{9}{11}{96/96}{Lab25: Generador Aleatorio de PDU}{0}}
 \headcommand {\beamer@framepages {96}{96}}
-\headcommand {\slideentry {1}{9}{12}{97/97}{GENERADOR ALEATORIO DE PDU}{0}}
+\headcommand {\slideentry {1}{9}{12}{97/97}{Lab25: Generador Aleatorio de PDU}{0}}
 \headcommand {\beamer@framepages {97}{97}}
-\headcommand {\slideentry {1}{9}{13}{98/98}{GENERADOR ALEATORIO DE PDU}{0}}
+\headcommand {\slideentry {1}{9}{13}{98/98}{Lab25: Generador Aleatorio de PDU}{0}}
 \headcommand {\beamer@framepages {98}{98}}
-\headcommand {\slideentry {1}{9}{14}{99/99}{GENERADOR ALEATORIO DE PDU}{0}}
+\headcommand {\slideentry {1}{9}{14}{99/99}{Lab25: Generador Aleatorio de PDU}{0}}
 \headcommand {\beamer@framepages {99}{99}}
-\headcommand {\slideentry {1}{9}{15}{100/100}{GENERADOR ALEATORIO DE PDU}{0}}
+\headcommand {\slideentry {1}{9}{15}{100/100}{Lab25: Generador Aleatorio de PDU}{0}}
 \headcommand {\beamer@framepages {100}{100}}
-\headcommand {\slideentry {1}{9}{16}{101/101}{GENERADOR ALEATORIO DE PDU}{0}}
+\headcommand {\slideentry {1}{9}{16}{101/101}{Lab25: Generador Aleatorio de PDU}{0}}
 \headcommand {\beamer@framepages {101}{101}}
-\headcommand {\slideentry {1}{9}{17}{103/103}{GENERADOR ALEATORIO DE PDU}{0}}
+\headcommand {\slideentry {1}{9}{17}{103/103}{Lab25: Generador Aleatorio de PDU}{0}}
 \headcommand {\beamer@framepages {103}{103}}
-\headcommand {\slideentry {1}{9}{18}{104/104}{GENERADOR ALEATORIO DE PDU}{0}}
+\headcommand {\slideentry {1}{9}{18}{104/104}{Lab25: Generador Aleatorio de PDU}{0}}
 \headcommand {\beamer@framepages {104}{104}}
-\headcommand {\slideentry {1}{9}{19}{106/106}{GENERADOR ALEATORIO DE PDU}{0}}
+\headcommand {\slideentry {1}{9}{19}{106/106}{Lab25: Generador Aleatorio de PDU}{0}}
 \headcommand {\beamer@framepages {106}{106}}
 \headcommand {\sectionentry {2}{BIBLIOGRAF\IeC {\'I}A}{108}{BIBLIOGRAF\IeC {\'I}A}{0}}
 \headcommand {\beamer@sectionpages {3}{107}}


### PR DESCRIPTION
Se cambio el fondo de algunas diapositivas que estaban mal y no seguían el orden que se llevaba, se actualizo la tabla de contenido y se ajustaron algunos títulos. Algunos laboratorios tienen imágenes borrosas y casi no se entienden. Se sugiere el cambio de estas, asi como no deformar el texto dentro de las imágenes al cambiar redimensionarlas.